### PR TITLE
Concentration skill bonus now cycles.

### DIFF
--- a/campaign/scripts/char_skill.lua
+++ b/campaign/scripts/char_skill.lua
@@ -16,7 +16,7 @@ end
 function updateWindow()
 	local sLabel = label.getValue();
 	local t = DataCommon.skilldata[sLabel];
-	if t then
+	if t and not t.custom then
 		setCustom(false);
 		
 		if t.stat then

--- a/scripts/data_common.lua
+++ b/scripts/data_common.lua
@@ -396,8 +396,12 @@ skilldata = {
 			stat = "intelligence"
 		},
 	["Concentration"] = {
-			stat = "wisdom"
-		},--Would love to have a toggle-able ability cycler here instead of a static one. Specifically, casting-ability-specific ones.
+			stat = "charisma",
+			-- 'custom' set to true will allow the skill used for
+			-- bonuses to cycle instead of being static. It will
+			-- start with charisma.
+			custom = true
+		},
 	["Diplomacy"] = {
 			stat = "charisma"
 		},


### PR DESCRIPTION
The skill bonus for Concentration now cycles by default. The cycle behavior can be added to any skill by adding the attribute custom = true
to the attribute in the data_common.lua file.
